### PR TITLE
Upgrade RstPreview.py and add a settings file for using docutils which is in other python site-packages(virtualenv)

### DIFF
--- a/RstPreview.py
+++ b/RstPreview.py
@@ -3,6 +3,7 @@ RstPreview renders reStructuredText files as HTML and shows them in your
 default browser.
 """
 
+import sys
 import os
 
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
@@ -11,6 +12,8 @@ from webbrowser import open as open_in_browser
 import sublime
 from sublime_plugin import TextCommand
 from sublime import Region
+
+SETTINGS_FILE = 'RstPreview.sublime-settings'
 
 
 def rst_to_html(rst_text):
@@ -60,6 +63,11 @@ def render_in_browser(html):
 class RstpreviewCommand(TextCommand):
 
     def run(self, edit):
+
+        settings = sublime.load_settings(SETTINGS_FILE)
+        site_packages_path = settings.get('site_packages_path')
+        if not site_packages_path in sys.path:
+            sys.path.append(site_packages_path)
 
         # Select all the text in the current document
         text = self.view.substr(Region(0, self.view.size()))

--- a/RstPreview.sublime-settings
+++ b/RstPreview.sublime-settings
@@ -1,0 +1,6 @@
+{
+    // Where to look for python site-packages directory.
+    // Use absolute path, not relative path.
+    // For example, "/Users/foo/.virtualenvs/env/lib/python2.x/site-packages".
+    "site_packages_path": ""
+}


### PR DESCRIPTION
Nice to meet you.
RstPreview is a nice Sublime Text 2 plugin.

The reason why I sent this pull request is that I usually use virtualenv and don't want to install docutils in global python site-packages.

You can use docutils in other python site-packages when you copy 'RstPreview.sublime-settings' file to 'Packages/Users' directory and write the path of other python site-packages in it.

Because of lack of time, I couldn't rewrite installation explanation in README.rst.

Sincerely yours.
