### PR TITLE
Write RST Preview to an HTML file instead of running a server

### DIFF
--- a/RstPreview.py
+++ b/RstPreview.py
@@ -7,6 +7,7 @@ import sys
 import os
 import webbrowser
 import tempfile
+import hashlib
 
 import sublime
 from sublime_plugin import TextCommand
@@ -48,7 +49,11 @@ class RstpreviewCommand(TextCommand):
         # Write that RST text as HTML
         html = rst_to_html(text)
         TEMP_DIR = tempfile.gettempdir()
-        file_path = os.path.join(TEMP_DIR, 'rst_preview.html')
+        if self.view.file_name():
+            preview_filename = hashlib.md5(self.view.file_name()).hexdigest()
+        else:
+            preview_filename = 'rst_preview.html'
+        file_path = os.path.join(TEMP_DIR, preview_filename)
         with open(file_path, 'w') as f:
             f.write(html)
 


### PR DESCRIPTION
I was having problems with the plugin crashing when I tried to re-preview a few too many times - writing to a tempfile and loading that in the browser seems to have less problems.
