### PR TITLE
Use short class names for syntax highlighting

### DIFF
--- a/RstPreview.py
+++ b/RstPreview.py
@@ -22,7 +22,8 @@ def rst_to_html(rst_text):
         bootstrap_css_path = os.path.join(sublime.packages_path(), 'RstPreview/css/bootstrap.min.css')
         base_css_path = os.path.join(sublime.packages_path(), 'RstPreview/css/base.css')
         args = {
-            'stylesheet_path': ','.join([bootstrap_css_path, base_css_path])
+            'stylesheet_path': ','.join([bootstrap_css_path, base_css_path]),
+            'syntax_highlight': 'short'
         }
         return publish_string(rst_text, writer_name='html', settings_overrides=args)
     except ImportError:


### PR DESCRIPTION
Fixes Issue #18

Pygments generated css styles use short class names, but docutils markups the source using long class names. Thus, code is not actually formatted when using the default settings.

This patch tells docutils to generate the markup using short class names, so pygments css styles properly highlight the resulting (marked up) code.
