### PR TITLE
Update RstPreview.py

### DIFF
--- a/RstPreview.py
+++ b/RstPreview.py
@@ -51,7 +51,7 @@ class RstpreviewCommand(TextCommand):
         html = rst_to_html(text)
         TEMP_DIR = tempfile.gettempdir()
         if self.view.file_name():
-            preview_filename = hashlib.md5(self.view.file_name()).hexdigest()
+            preview_filename = hashlib.md5(self.view.file_name()).hexdigest() + ".html"
         else:
             preview_filename = 'rst_preview.html'
         file_path = os.path.join(TEMP_DIR, preview_filename)


### PR DESCRIPTION
add html suffix to hexdigest filename as well.  

At least on my Mac, this makes Safari happy by preventing it from downloading the file to my Downloads directory instead of showing it.  
